### PR TITLE
Connect to the Movistar SMS API

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -78,6 +78,7 @@ search:
    - app/
    - db/pages/
    - db/custom_seeds.rb
+   - lib/
 
   ## Root directories for relative keys resolution.
   # relative_roots:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -963,3 +963,5 @@ es:
     create:
       enqueue_remote_translation: Se han solicitado correctamente las traducciones.
     button: Traducir página
+  sms_api:
+    message: "Clave para verificarte: %{code}. Gobierno Abierto"

--- a/config/locales/gl/general.yml
+++ b/config/locales/gl/general.yml
@@ -821,3 +821,5 @@ gl:
       alt: Escolle o texto que queres comentar e preme o botón que ten forma do lapis.
       text: Para comentar este documento, debes %{sign_in}%{sign_up}. Despois, escolle o texto que queres comentar e preme o botón que ten forma de lapis.
       title: Como podo comentar este documento?
+  sms_api:
+    message: "Clave para verificarse: %{code}. Goberno aberto"

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -15,6 +15,7 @@ apis: &apis
   sms_end_point:  ""
   sms_username: ""
   sms_password: ""
+  sms_sender:  ""
 
 http_basic_auth: &http_basic_auth
   http_basic_auth: true

--- a/spec/fixtures/files/sms_api/error.xml
+++ b/spec/fixtures/files/sms_api/error.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <SubmitRes xmlns="http://www.telefonica.es/MI/InterfazSimplificado/schemas">
+      <Version xmlns="">1.0</Version>
+      <Status xmlns="">
+        <StatusCode>4000</StatusCode>
+        <StatusText>General service error</StatusText>
+        <Details>Generic service error</Details>
+      </Status>
+    </SubmitRes>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/fixtures/files/sms_api/success.xml
+++ b/spec/fixtures/files/sms_api/success.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <SubmitRes xmlns="http://www.telefonica.es/MI/InterfazSimplificado/schemas">
+      <Version xmlns="">1.0</Version>
+      <Status xmlns="">
+        <StatusCode>1000</StatusCode>
+        <StatusText>Success</StatusText>
+        <Details>Message sent</Details>
+      </Status>
+    </SubmitRes>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/lib/sms_api_spec.rb
+++ b/spec/lib/sms_api_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require "savon/mock/spec_helper"
+
+describe SMSApi do
+  let(:api) { SMSApi.new }
+
+  context "#sms_deliver" do
+    include Savon::SpecHelper
+
+    before do
+      endpoint = "https://www.mensajerianegocios.movistar.es/MiInterfazSImplificado.wsdl"
+      allow(Rails.application.secrets).to receive(:sms_end_point).and_return(endpoint)
+      savon.mock!
+    end
+
+    after do
+      savon.unmock!
+    end
+
+    it "returns true when web service response is success" do
+      success = File.read("spec/fixtures/files/sms_api/success.xml")
+      savon.expects(:sms_text_submit).with(message: :any).returns(success)
+
+      response = api.sms_deliver("666777888", "AAAA")
+
+      expect(response).to be_truthy
+    end
+
+    it "returns false when web service response is error" do
+      error = File.read("spec/fixtures/files/sms_api/error.xml")
+      savon.expects(:sms_text_submit).with(message: :any).returns(error)
+
+      response = api.sms_deliver("", "AAAA")
+
+      expect(response).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
## References
Related Issues: #5 

## Objectives
Connect to the [API Mensajería Negocios v3.0](https://www.mensajerianegocios.movistar.es/Manual_Mensajeria_Negocios_API.pdf)

## Notes
This PR adds a new secret entry so remember to update the `secrets.yml` file on your servers with the `Sender` code. Movistar will provide your account with this identifier.

**Testing successfully on production environment!**
